### PR TITLE
Added README for export instructions to PDF

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "markdown-pdf.format": "A4"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Obscuro Whitepaper
+
+## Output as PDF
+
+1. Install [Merge-Markdown](https://www.npmjs.com/package/merge-markdown)
+2. Install [Markdown-PDF](https://marketplace.visualstudio.com/items?itemName=yzane.markdown-pdf)
+3. Execute `merge-markdown -m manifest.yaml`
+4. Open `whitepaper.md` and execute `Markdown PDF: Export (PDF)` in the VS Code command palette:
+    - For MacOS: <kbd>⌘ Command</kbd> + <kbd>⇧ Shift</kbd> + <kbd>P</kbd>
+    - For Windows: <kbd>CTRL</kbd> + <kbd>⇧ Shift</kbd> + <kbd>P</kbd>

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,17 @@
+---
+input:
+  abstract.md: ""
+  motivation.md: ""
+  context.md: ""
+  high-level-design.md: ""
+  technical-background.md: ""
+  detailed-design/rollup-data-structure.md: ""
+  detailed-design/aggregators-verifiers.md: ""
+  detailed-design/registrations.md: ""
+  detailed-design/pobi.md: ""
+  detailed-design.md: ""
+  detailed-design/state-confidentiality-wallets.md: ""
+  governance.md: ""
+  appendix.md: ""
+output: whitepaper.md
+---


### PR DESCRIPTION
- You can merge all markdown files in the order defined by `manifest.yaml`, then export as PDF using Markdown-PDF VSCode Extension.
- Markdown-PDF custom settings can be defined under `.vscode/settings.json`